### PR TITLE
Remove extra slash

### DIFF
--- a/jupyterhub_configurator/templates/index.html
+++ b/jupyterhub_configurator/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>JupyterHub Configurator</title>
-<script defer src="{{ base_url }}/static/index.js"></script></head>
+<script defer src="{{ base_url }}static/index.js"></script></head>
 <body>
 
     <div id="root">


### PR DESCRIPTION
Without this change, the request looks like this (notice the double slash in `filename`):

```
GET
scheme: http
host: localhost:8000
filename: /services/configurator//static/index.js
```
This doesn't seem to be causing any issues and returns a `200` when using JupyterHub with CHP. But when I tried to use it with traefik-proxy, I got a `404`. Maybe CHP is doing some extra magic to the resource url before passing it over to the server... Not sure.

Removing the extra slash from the request seems to solve this issue.
`base_url` (JUPYTERHUB_SERVICE_PREFIX) seems to be always ending in a `/`, so it shouldn't be an issue.
https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/services/service.py#L316-L317