### PR TITLE
Add an example of how the user docker image should be set

### DIFF
--- a/jupyterhub_configurator/schemas/z2jh.py
+++ b/jupyterhub_configurator/schemas/z2jh.py
@@ -8,7 +8,7 @@ def jupyterhub_configurator_fields():
             "type": "string",
             "title": "User docker image",
             "description": "Determines languages, libraries and interfaces available",
-            "help": "Leave this blank to use the default",
+            "help": "Eg. \"quay.io/org/user-image:c4e586ff9240\". Leave this blank to use the default.",
             "traitlet": "KubeSpawner.image",
         },
         "z2jh.default_interface": {


### PR DESCRIPTION
I believe it would be useful to have an inline example on how we expect the docker image to be specified.